### PR TITLE
Blog card truncate

### DIFF
--- a/src/components/BlogWidget.jsx
+++ b/src/components/BlogWidget.jsx
@@ -45,18 +45,18 @@ const BlogWidget = props => {
                         <CardBody>
                             <Link to={edge.node.frontmatter.path}>
                                 <CardTitle tag="h4">
-                                    {_.truncate(edge.node.frontmatter.title,{
-                                    'length': 25,
-                                'omission': ' [...]'})}
+                                    {edge.node.frontmatter.title}
                                 </CardTitle>
                             </Link>
                         </CardBody>
                         <CardImgOverlay className="d-none d-lg-block">
                             <CardBody>
                                 <CardText>
-                                    {edge.node.frontmatter.excerpt ? (
-                                        edge.node.frontmatter.excerpt
-                                    ) : (
+                                    {_.truncate(edge.node.frontmatter.excerpt, {
+                                    'omission': ' ...'}) ? _.truncate(
+                                        edge.node.frontmatter.excerpt,{
+                                        'omission': ' ...'})
+                                     : (
                                         <Loading />
                                     )}
                                 </CardText>

--- a/src/components/BlogWidget.jsx
+++ b/src/components/BlogWidget.jsx
@@ -53,10 +53,10 @@ const BlogWidget = props => {
                             <CardBody>
                                 <CardText>
                                     {_.truncate(edge.node.frontmatter.excerpt, {
-                                    'length': 80,
+                                    'length': 145,
                                     'omission': ' ...'}) ? _.truncate(
                                         edge.node.frontmatter.excerpt,{
-                                        'length': 80,
+                                        'length': 145,
                                         'omission': ' ...'})
                                      : (
                                         <Loading />

--- a/src/components/BlogWidget.jsx
+++ b/src/components/BlogWidget.jsx
@@ -53,8 +53,10 @@ const BlogWidget = props => {
                             <CardBody>
                                 <CardText>
                                     {_.truncate(edge.node.frontmatter.excerpt, {
+                                    'length': 80,
                                     'omission': ' ...'}) ? _.truncate(
                                         edge.node.frontmatter.excerpt,{
+                                        'length': 80,
                                         'omission': ' ...'})
                                      : (
                                         <Loading />

--- a/src/components/BlogWidget.jsx
+++ b/src/components/BlogWidget.jsx
@@ -15,6 +15,7 @@ import {
     Button,
 } from "reactstrap";
 import Loading from "./loading.jsx";
+import _ from "lodash";
 
 // Blog post widget to display 3 blog posts from graphQL data.
 // When using this widget, make sure to pass a prop, "posts",
@@ -44,7 +45,9 @@ const BlogWidget = props => {
                         <CardBody>
                             <Link to={edge.node.frontmatter.path}>
                                 <CardTitle tag="h4">
-                                    {edge.node.frontmatter.title}
+                                    {_.truncate(edge.node.frontmatter.title,{
+                                    'length': 25,
+                                'omission': ' [...]'})}
                                 </CardTitle>
                             </Link>
                         </CardBody>

--- a/src/pages/alkemy-blog.js
+++ b/src/pages/alkemy-blog.js
@@ -15,6 +15,8 @@ import RecentBlogs from "../components/RecentBlogs.jsx";
 import LatestFromCategory from "../components/LatestFromCategory.jsx";
 import PropTypes from "prop-types";
 
+
+
 /*
 Layout props:
   pageTitle: SEO friendly title for the title bar

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -2,6 +2,7 @@ import React,{useEffect} from "react";
 import { graphql, Link } from "gatsby";
 import Img from "gatsby-image";
 import { fluidImageSmall } from "../utils/utils.js";
+import { trunc } from "../utils/utils.js";
 import {
     CardDeck,
     Card,

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -10,6 +10,10 @@ export const fluidImage = graphql`
     }
 `;
 
+export const trunc = data => {
+    return data.substring(0, 50) + "...";
+};
+
 export const fluidImageSmall = graphql`
     fragment fluidImageSmall on File {
         childImageSharp {


### PR DESCRIPTION
This references issue #71 
Added truncate function from lodash to truncate recent blog card overlay. Text was previously escaping the card and behind the "Read More" button on lower resolution/tablet displays. 